### PR TITLE
Fix jsonc parser issue with quotes in strings

### DIFF
--- a/src/objdictgen/jsonod.py
+++ b/src/objdictgen/jsonod.py
@@ -167,10 +167,10 @@ SUBINDEX0 = {
 
 # Remove jsonc annotations
 # Copied from https://github.com/NickolaiBeloguzov/jsonc-parser/blob/master/jsonc_parser/parser.py#L11-L39
-RE_JSONC = re.compile(r"(\".*?\"|\'.*?\')|(/\*.*?\*/|//[^\r\n]*$)", re.MULTILINE | re.DOTALL)
+RE_JSONC = re.compile(r"(\".*?(?<!\\)\"|\'.*?\')|(\s*/\*.*?\*/\s*|\s*//[^\r\n]*$)", re.MULTILINE | re.DOTALL)
 
 
-def remove_jasonc(text: str) -> str:
+def remove_jsonc(text: str) -> str:
     """ Remove jsonc annotations """
     def _re_sub(match: re.Match[str]) -> str:
         if match.group(2) is not None:
@@ -406,7 +406,7 @@ def generate_node(contents: str|TODJson) -> "Node":
     if isinstance(contents, str):
 
         # Remove jsonc annotations
-        jsontext = remove_jasonc(contents)
+        jsontext = remove_jsonc(contents)
 
         # Load the json
         jd: TODJson = json.loads(jsontext)
@@ -426,7 +426,7 @@ def generate_node(contents: str|TODJson) -> "Node":
     global SCHEMA  # pylint: disable=global-statement
     if not SCHEMA:
         with open(objdictgen.JSON_SCHEMA, 'r', encoding="utf-8") as f:
-            SCHEMA = json.loads(remove_jasonc(f.read()))
+            SCHEMA = json.loads(remove_jsonc(f.read()))
 
     if SCHEMA and jd.get('$version') == JSON_VERSION:
         jsonschema.validate(jd, schema=SCHEMA)

--- a/tests/test_jsonod.py
+++ b/tests/test_jsonod.py
@@ -1,8 +1,50 @@
 import pytest
 from pprint import pprint
 from objdictgen import Node
-from objdictgen.jsonod import generate_jsonc, generate_node
+from objdictgen.jsonod import generate_jsonc, generate_node, remove_jsonc
 from .test_odcompare import shave_equal
+
+
+def test_jsonod_remove_jsonc():
+    """ Test that the remove_jsonc function works as expected. """
+
+    out = remove_jsonc("""{
+"a": "abc",  // remove
+"b": 42
+}""")
+    assert out == """{
+"a": "abc",
+"b": 42
+}"""
+
+    # This was a bug where there quoted string made jsonc parsing fail
+    out = remove_jsonc("""{
+"a": "a\\"bc",  // remove
+"b": 42
+}""")
+    assert out == """{
+"a": "a\\"bc",
+"b": 42
+}"""
+
+    out = remove_jsonc("""{
+"a": "a\\"bc",  /* remove it */ "c": 42,
+"b": 42
+}""")
+    assert out == """{
+"a": "a\\"bc","c": 42,
+"b": 42
+}"""
+
+    out = remove_jsonc("""{
+"a": "a'bc",  // remove
+"b": 42
+}""")
+    assert out == """{
+"a": "a'bc",
+"b": 42
+}"""
+
 
 def test_jsonod_roundtrip(odjsoneds):
     """ Test that the file can be exported to json and that the loaded file


### PR DESCRIPTION
This PR fixes issues with JSON files that contains statements with a single escaped quote, like `"value": "Hello\" World"`. This was due to the JSONC parser that were confused by the quote.