### PR TITLE
Add no canfestival option

### DIFF
--- a/src/objdictgen/__main__.py
+++ b/src/objdictgen/__main__.py
@@ -141,6 +141,7 @@ def main(debugopts: DebugOpts, args: Sequence[str]|None = None):
                         help="Store in internal format (json only)")
     subp.add_argument('--no-sort', action="store_true",
                         help="Don't order of parameters in output OD")
+    subp.add_argument('--no-can-festival', action='store_true', help="Generate a second set of files, modified to not include from canfestival")
 
     # -- DIFF --
     subp = subparser.add_parser('diff', parents=[common_opts], help="""
@@ -263,7 +264,7 @@ def main(debugopts: DebugOpts, args: Sequence[str]|None = None):
         od.DumpFile(opts.out,
             filetype=opts.type,
             # These additional options are only used for JSON output
-            sort=not opts.no_sort, internal=opts.internal, validate=not opts.novalidate
+            sort=not opts.no_sort, internal=opts.internal, validate=not opts.novalidate, no_can_festival=opts.no_can_festival
         )
 
 

--- a/src/objdictgen/gen_cfile.py
+++ b/src/objdictgen/gen_cfile.py
@@ -137,9 +137,9 @@ class CFileContext(UserDict):
             raise ValueError(f"!!! '{typename}' isn't a valid type for CanFestival.")
 
         if result[1] == "UNSIGNED" and int(result[2]) in [i * 8 for i in range(1, 9)]:
-            typeinfos = TypeInfos(f"UNS{result[2]}", None, f"uint{result[2]}_t", True)
+            typeinfos = TypeInfos(f"UNS{result[2]}", None, f"uint{result[2]}", True)
         elif result[1] == "INTEGER" and int(result[2]) in [i * 8 for i in range(1, 9)]:
-            typeinfos = TypeInfos(f"INTEGER{result[2]}", None, f"int{result[2]}_t", False)
+            typeinfos = TypeInfos(f"INTEGER{result[2]}", None, f"int{result[2]}", False)
         elif result[1] == "REAL" and int(result[2]) in (32, 64):
             typeinfos = TypeInfos(f"{result[1]}{result[2]}", None, f"real{result[2]}", False)
         elif result[1] in ["VISIBLE_STRING", "OCTET_STRING"]:
@@ -155,7 +155,7 @@ class CFileContext(UserDict):
                 size = max(size, len(item))
             typeinfos = TypeInfos("UNS8", size, "domain", False)
         elif result[1] == "BOOLEAN":
-            typeinfos = TypeInfos("UNS8", None, "bool", False)
+            typeinfos = TypeInfos("UNS8", None, "boolean", False)
         else:
             # FIXME: The !!! is for special UI handling
             raise ValueError(f"!!! '{typename}' isn't a valid type for CanFestival.")
@@ -193,7 +193,23 @@ def compute_value(value: TODValue, ctype: str) -> tuple[str, str]:
 def convert_from_canopen_to_c_type(type):
     # Used to convert types when ctype is an illegal value (e.g. valueRange_X)
     type_map = {}
-    type_map["UNS8"] = "uint8_t"
+    type_map["boolean"] = "bool"
+    type_map["int8"] = "int8_t"
+    type_map["int16"] = "int16_t"
+    type_map["int32"] = "int32_t"
+    type_map["int40"] = "int64_t"
+    type_map["int48"] = "int64_t"
+    type_map["int56"] = "int64_t"
+    type_map["int64"] = "int64_t"
+    type_map["uint8"] = "uint8_t"
+    type_map["uint16"] = "uint16_t"
+    type_map["uint32"] = "uint32_t"
+    type_map["uint40"] = "uint64_t"
+    type_map["uint48"] = "uint64_t"
+    type_map["uint56"] = "uint64_t"
+    type_map["uint64"] = "uint64_t"
+    type_map["real32"] = "float"
+    type_map["real64"] = "double"
 
     try:
         value = type_map[type]
@@ -342,11 +358,11 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                     "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00 */\n"
                 )
                 if "valueRange_" in typeinfos.ctype:
-                    ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.type)
+                    ctx["subIndexType"] = "uint8_t"
                 elif typeinfos.ctype == "visible_string":
                     ctx["subIndexType"] = "const char*"
                 else:
-                    ctx["subIndexType"] = typeinfos.ctype
+                    ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.ctype)
                 noCanFestivalDeclarations %= (
                     "extern {subIndexType} {name}{suffix};"
                     "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00*/\n"
@@ -398,11 +414,11 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                         "/* Mapped at index 0x{index:04X}, subindex 0x01 - 0x{length:02X} */\n  {{\n"
                     )
                     if "valueRange_" in typeinfos.ctype:
-                        ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.type)
+                        ctx["subIndexType"] = "uint8_t"
                     elif typeinfos.ctype == "visible_string":
                         ctx["subIndexType"] = "const char*"
                     else:
-                        ctx["subIndexType"] = typeinfos.ctype
+                        ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.ctype)
                     noCanFestivalDeclarations %= (
                         "extern {subIndexType} {name}{suffix};"
                         "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00*/\n"
@@ -474,13 +490,13 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                                 "/* Mapped at index 0x{index:04X}, subindex 0x{subindex:02X} */\n"
                             )
                             if "valueRange_" in typeinfos.ctype:
-                                ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.type)
+                                ctx["subIndexType"] = "uint8_t"
                             elif typeinfos.ctype == "visible_string":
                                 ctx["subIndexType"] = "const char*"
                             else:
-                                ctx["subIndexType"] = typeinfos.ctype
+                                ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.ctype)
                             noCanFestivalDeclarations %= (
-                                "extern {subIndexType} {name}{suffix};"
+                                "extern {subIndexType} {parent}_{name}{suffix};"
                                 "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00*/\n"
                             )
                             noCanFestivalDefinitions %= (

--- a/src/objdictgen/gen_cfile.py
+++ b/src/objdictgen/gen_cfile.py
@@ -441,7 +441,9 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                                     f"index: 0x{index:04X}, subindex: 0x{subindex:02X}"
                                 )
                             mappedVariableContent += f"    {value}{sep}{comment}\n"
+                            noCanFestivalDefinitions += f"    {value}{sep}{comment}\n"
                     mappedVariableContent += "  };\n"
+                    noCanFestivalDefinitions += "  };\n"
                 else:
                     strindex %= (
                         "                    "

--- a/src/objdictgen/gen_cfile.py
+++ b/src/objdictgen/gen_cfile.py
@@ -52,7 +52,8 @@ class TypeInfos:
     """Type infos for a type."""
     type: str
     size: int|None
-    ctype: str
+    ctype: str # holds raw c type (e.g. uint8_t, bool, const char*)
+    cftype: str # hols canfestival type (e.g. uint8, boolean, visible_string)
     is_unsigned: bool
 
 
@@ -137,31 +138,31 @@ class CFileContext(UserDict):
             raise ValueError(f"!!! '{typename}' isn't a valid type for CanFestival.")
 
         if result[1] == "UNSIGNED" and int(result[2]) in [i * 8 for i in range(1, 9)]:
-            typeinfos = TypeInfos(f"UNS{result[2]}", None, f"uint{result[2]}_t", True)
+            typeinfos = TypeInfos(f"UNS{result[2]}", None, f"uint{result[2]}_t", f"uint{result[2]}", True)
         elif result[1] == "INTEGER" and int(result[2]) in [i * 8 for i in range(1, 9)]:
-            typeinfos = TypeInfos(f"INTEGER{result[2]}", None, f"int{result[2]}_t", False)
+            typeinfos = TypeInfos(f"INTEGER{result[2]}", None, f"int{result[2]}_t", f"int{result[2]}", False)
         elif result[1] == "REAL" and int(result[2]) in (32, 64):
-            typeinfos = TypeInfos(f"{result[1]}{result[2]}", None, f"real{result[2]}", False)
+            typeinfos = TypeInfos(f"{result[1]}{result[2]}", None, "float" if result[2] == 32 else "double", f"real{result[2]}", False)
         elif result[1] in ["VISIBLE_STRING", "OCTET_STRING"]:
             size = self.default_string_size
             for item in items:
                 size = max(size, len(item))
             if result[2]:
                 size = max(size, int(result[2]))
-            typeinfos = TypeInfos("UNS8", size, "visible_string", False)
+            typeinfos = TypeInfos("UNS8", size, "const char*", "visible_string", False)
         elif result[1] == "DOMAIN":
             size = 0
             for item in items:
                 size = max(size, len(item))
-            typeinfos = TypeInfos("UNS8", size, "domain", False)
+            typeinfos = TypeInfos("UNS8", size, "domain", "domain", False)
         elif result[1] == "BOOLEAN":
-            typeinfos = TypeInfos("UNS8", None, "bool", False)
+            typeinfos = TypeInfos("UNS8", None, "bool", "boolean", False)
         else:
             # FIXME: The !!! is for special UI handling
             raise ValueError(f"!!! '{typename}' isn't a valid type for CanFestival.")
 
         # Cache the typeinfos
-        if typeinfos.ctype not in ["visible_string", "domain"]:
+        if typeinfos.cftype not in ["visible_string", "domain"]:
             self.internal_types[typename] = typeinfos
         return typeinfos
 
@@ -184,7 +185,9 @@ def compute_value(value: TODValue, ctype: str) -> tuple[str, str]:
     if ctype.startswith("real"):
         return str(value), ""
     # FIXME: Assume value is an integer
-    assert not isinstance(value, str)
+    if isinstance(value, str):
+        print(value)
+    assert not isinstance(value, str), "value is a str"
     # Make sure to handle negative numbers correctly
     if value < 0:
         return f"-0x{-value:X}", f"\t/* {value} */"
@@ -244,7 +247,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
       if (*(UNS8*)value != (UNS8)0) return OD_VALUE_RANGE_EXCEEDED;
       break;
 """)
-    ctx.internal_types["valueRange_EMC"] = TypeInfos("UNS8", 0, "valueRange_EMC", True)
+    ctx.internal_types["valueRange_EMC"] = TypeInfos("UNS8", 0, "valueRange_EMC", "valueRange_EMC", True)
     num = 0
     for index in rangelist:
         rangename = node.GetEntryName(index)
@@ -258,7 +261,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
             typename = node.GetTypeName(typeindex)
             typeinfos = ctx.get_valid_type_infos(typename)
             ctx.internal_types[rangename] = TypeInfos(
-                typeinfos.type, typeinfos.size, f"valueRange_{num}", typeinfos.is_unsigned
+                typeinfos.type, typeinfos.size, typeinfos.ctype, f"valueRange_{num}", typeinfos.is_unsigned
             )
             minvalue = node.GetEntry(index, 2)
             maxvalue = node.GetEntry(index, 3)
@@ -330,7 +333,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                     ctx["suffix"] = f"[{typeinfos.size}]"
             else:
                 ctx["suffix"] = ""
-            ctx["value"], ctx["comment"] = compute_value(values, typeinfos.ctype)
+            ctx["value"], ctx["comment"] = compute_value(values, typeinfos.cftype)
             if index in variablelist:
                 ctx["name"] = RE_STARTS_WITH_DIGIT.sub(r'_\1', format_name(subentry_infos["name"]))
                 strDeclareHeader %= (
@@ -341,12 +344,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                     "{subIndexType} {name}{suffix} = {value};"
                     "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00 */\n"
                 )
-                if "valueRange_" in typeinfos.ctype:
-                    ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.type)
-                elif typeinfos.ctype == "visible_string":
-                    ctx["subIndexType"] = "const char*"
-                else:
-                    ctx["subIndexType"] = typeinfos.ctype
+                ctx["subIndexType"] = typeinfos.ctype
                 noCanFestivalDeclarations %= (
                     "extern {subIndexType} {name}{suffix};"
                     "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00*/\n"
@@ -397,12 +395,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                         "{subIndexType} {name}[]{suffix} =\t\t"
                         "/* Mapped at index 0x{index:04X}, subindex 0x01 - 0x{length:02X} */\n  {{\n"
                     )
-                    if "valueRange_" in typeinfos.ctype:
-                        ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.type)
-                    elif typeinfos.ctype == "visible_string":
-                        ctx["subIndexType"] = "const char*"
-                    else:
-                        ctx["subIndexType"] = typeinfos.ctype
+                    ctx["subIndexType"] = typeinfos.ctype
                     noCanFestivalDeclarations %= (
                         "extern {subIndexType} {name}{suffix};"
                         "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00*/\n"
@@ -418,7 +411,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                         if subindex > 0:
                             if subindex == len(values) - 1:
                                 sep = ""
-                            value, comment = compute_value(value, typeinfos.ctype)
+                            value, comment = compute_value(value, typeinfos.cftype)
                             if len(value) == 2 and typename == "DOMAIN":
                                 raise ValueError(
                                     "Domain variable not initialized, "
@@ -437,7 +430,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                         if subindex > 0:
                             if subindex == len(values) - 1:
                                 sep = ""
-                            value, comment = compute_value(value, typeinfos.ctype)
+                            value, comment = compute_value(value, typeinfos.cftype)
                             strindex += f"                      {value}{sep}{comment}\n"
                     strindex += "                    };\n"
             else:
@@ -445,6 +438,8 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                 ctx["parent"] = RE_STARTS_WITH_DIGIT.sub(r'_\1', format_name(entry_infos["name"]))
                 # Entry type is RECORD
                 for subindex, value in enumerate(values):
+                    if value == "":
+                        continue
                     ctx["subindex"] = subindex
                     # FIXME: Are there any point in calling this for subindex 0?
                     params_infos = node.GetParamsEntry(index, subindex)
@@ -462,7 +457,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                                 ctx["suffix"] = f"[{typeinfos.size}]"
                         else:
                             ctx["suffix"] = ""
-                        ctx["value"], ctx["comment"] = compute_value(value, typeinfos.ctype)
+                        ctx["value"], ctx["comment"] = compute_value(value, typeinfos.cftype)
                         ctx["name"] = format_name(subentry_infos["name"])
                         if index in variablelist:
                             strDeclareHeader %= (
@@ -473,12 +468,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                                 "{subIndexType} {parent}_{name}{suffix} = {value};\t\t"
                                 "/* Mapped at index 0x{index:04X}, subindex 0x{subindex:02X} */\n"
                             )
-                            if "valueRange_" in typeinfos.ctype:
-                                ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.type)
-                            elif typeinfos.ctype == "visible_string":
-                                ctx["subIndexType"] = "const char*"
-                            else:
-                                ctx["subIndexType"] = typeinfos.ctype
+                            ctx["subIndexType"] = typeinfos.ctype
                             noCanFestivalDeclarations %= (
                                 "extern {subIndexType} {name}{suffix};"
                                 "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00*/\n"
@@ -543,7 +533,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                         f"{ctx['NodeName']}_obj{ctx['index']:04X}_"
                         f"{format_name(subentry_infos['name'])}"
                     )
-            if typeinfos.ctype == "visible_string":
+            if typeinfos.cftype == "visible_string":
                 if params_infos["buffer_size"]:
                     sizeof = str(params_infos["buffer_size"])
                 else:
@@ -551,7 +541,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                     # FIXME: It should be a str type with visible_string
                     assert isinstance(value, str)
                     sizeof = str(max(len(value), ctx.default_string_size))
-            elif typeinfos.ctype == "domain":
+            elif typeinfos.cftype == "domain":
                 value = values[subindex]
                 # FIXME: Value should be string
                 assert isinstance(value, str)
@@ -569,7 +559,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
             strindex += (
                 f"                       {{ "
                 f"{subentry_infos['access'].upper()}{save}, "
-                f"{typeinfos.ctype}, {sizeof}, (void*)&{start_digit}, NULL "
+                f"{typeinfos.cftype}, {sizeof}, (void*)&{start_digit}, NULL "
                 f"}}{sep}\n"
             )
             pointer_name = pointers_dict.get((index, subindex), None)

--- a/src/objdictgen/gen_cfile.py
+++ b/src/objdictgen/gen_cfile.py
@@ -360,7 +360,7 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                 if "valueRange_" in typeinfos.ctype:
                     ctx["subIndexType"] = "uint8_t"
                 elif typeinfos.ctype == "visible_string":
-                    ctx["subIndexType"] = "const char*"
+                    ctx["subIndexType"] = "char"
                 else:
                     ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.ctype)
                 noCanFestivalDeclarations %= (
@@ -416,16 +416,16 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                     if "valueRange_" in typeinfos.ctype:
                         ctx["subIndexType"] = "uint8_t"
                     elif typeinfos.ctype == "visible_string":
-                        ctx["subIndexType"] = "const char*"
+                        ctx["subIndexType"] = "char"
                     else:
                         ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.ctype)
                     noCanFestivalDeclarations %= (
-                        "extern {subIndexType} {name}{suffix};"
-                        "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00*/\n"
+                        "extern {subIndexType} {name}[{values_count}]{suffix};\t\t"
+                        "/* Mapped at index 0x{index:04X}, subindex 0x01 - 0x{length:02X} */\n"
                     )
                     noCanFestivalDefinitions %= (
-                        "{subIndexType} {name}{suffix} = {value};"
-                        "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00 */\n"
+                        "{subIndexType} {name}[]{suffix} =\t\t"
+                        "/* Mapped at index 0x{index:04X}, subindex 0x01 - 0x{length:02X} */\n  {{\n"
                     )
                     ctx["subIndexType"] = typeinfos.type
 
@@ -492,12 +492,12 @@ def generate_file_content(node: NodeProtocol, headerfile: str, no_can_festival: 
                             if "valueRange_" in typeinfos.ctype:
                                 ctx["subIndexType"] = "uint8_t"
                             elif typeinfos.ctype == "visible_string":
-                                ctx["subIndexType"] = "const char*"
+                                ctx["subIndexType"] = "char"
                             else:
                                 ctx["subIndexType"] = convert_from_canopen_to_c_type(typeinfos.ctype)
                             noCanFestivalDeclarations %= (
-                                "extern {subIndexType} {parent}_{name}{suffix};"
-                                "\t\t/* Mapped at index 0x{index:04X}, subindex 0x00*/\n"
+                                "extern {subIndexType} {parent}_{name}{suffix};\t\t"
+                                "/* Mapped at index 0x{index:04X}, subindex 0x{subindex:02X} */\n"
                             )
                             noCanFestivalDefinitions %= (
                                 "{subIndexType} {parent}_{name}{suffix} = {value};\t\t"

--- a/src/objdictgen/node.py
+++ b/src/objdictgen/node.py
@@ -192,7 +192,7 @@ class Node(NodeProtocol):
         """ Import a new Node from a JSON string """
         return jsonod.generate_node(contents, validate=validate)
 
-    def DumpFile(self, filepath: TPath, filetype: str|None = "jsonc", **kwargs):
+    def DumpFile(self, filepath: TPath, filetype: str|None = "jsonc", no_can_festival=False, **kwargs):
         """ Save node into file """
 
         # Attempt to determine the filetype from the filepath
@@ -227,7 +227,7 @@ class Node(NodeProtocol):
         if filetype == 'c':
             log.debug("Writing C files '%s'", filepath)
             # Convert filepath to str because it might be used with legacy code
-            gen_cfile.GenerateFile(str(filepath), self)
+            gen_cfile.GenerateFile(str(filepath), self, no_can_festival)
             return
 
         raise ValueError("Unknown file suffix, unable to write file")


### PR DESCRIPTION
I added command line arg that will give the option to generate an extra set of .h/.c files which do not include any reference to canfestival (the #include "data.h" and the types).

I ran odg convert on the same .od file in main and in my branch and a diff shows that there is no difference between before and after my changes. I've attached the files to this PR, notice that the only diff is in the #ifndef sections.

I had to rename the files because GitHub does not allow me to upload .c and .h files
[abc_new_c.txt](https://github.com/user-attachments/files/22792870/abc_new_c.txt)
[abc_new_h.txt](https://github.com/user-attachments/files/22792872/abc_new_h.txt)
[abc_new_objectdefines_h.txt](https://github.com/user-attachments/files/22792873/abc_new_objectdefines_h.txt)
[abc_objectdefines_h.txt](https://github.com/user-attachments/files/22792874/abc_objectdefines_h.txt)
[abc_c.txt](https://github.com/user-attachments/files/22792875/abc_c.txt)
[abc_h.txt](https://github.com/user-attachments/files/22792876/abc_h.txt)
